### PR TITLE
Handle empty balance bullet for empty daily types

### DIFF
--- a/index.html
+++ b/index.html
@@ -689,7 +689,11 @@
       if (rpe>=7) bullets.push('Высокая усталость → уменьшили объём, меньше силы, больше мобилити/дыхания.');
       if (rpeLowStreak>=2 && rpe<=3) bullets.push('Низкая усталость последние дни → добавили сложность/объём.');
       if (pain.length) bullets.push(`Исключили нагрузки на: ${pain.join(', ')}.`);
-      bullets.push(`Баланс стимулов: ${typesToday.join(' + ')}.`);
+      if (typesToday.length) {
+        bullets.push(`Баланс стимулов: ${typesToday.join(' + ')}.`);
+      } else {
+        bullets.push('Фокус: восстановление/дыхание.');
+      }
       bullets.push(`KPI дня: «комфортная осанка»/ROM целевой области без болезненности.`);
 
       // dominant area by minutes


### PR DESCRIPTION
## Summary
- add a fallback when no stretching or LFK types are present today
- keep the "Баланс стимулов" bullet only when types are available

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e23ec4d5e0832d8810b1fd2689a691