### PR TITLE
Adjust Sunday recovery stretch pools

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,7 +227,7 @@
       { id:'thu_ankle',     dow:4, title:'Стопа и голеностоп',    pools:['area:ankle','area:balance'],   include:['type:mobility','type:strength'] },
       { id:'fri_integration',dow:5,title:'Интеграция и координация', pools:['area:core','area:balance'], include:['type:stability','type:balance'] },
       { id:'sat_deload',    dow:6, title:'Длинная прогулка + мобилити', pools:['area:hips','area:tspine'], include:['type:mobility'] },
-      { id:'sun_active',    dow:7, title:'Активное восстановление', pools:['area:breath','area:balance'], include:['type:awareness','type:breath'] },
+      { id:'sun_active',    dow:7, title:'Активное восстановление', pools:['area:breath','area:balance','area:neck','area:tspine','area:shoulder','area:hips','area:hamstrings'], include:['type:awareness','type:breath','type:mobility'] },
     ];
 
     const GOAL_CONFIG = {


### PR DESCRIPTION
## Summary
- expand the Sunday "Активное восстановление" theme pools to include areas covered by existing stretch exercises
- prefer mobility work alongside breath/awareness entries so the stretch card fills with current content

## Testing
- node - <<'NODE' # ad-hoc check verifying Sunday stretch pack uses available exercises


------
https://chatgpt.com/codex/tasks/task_e_68e23ec7ccb0832db3841c70dbf1204f