### PR TITLE
Normalize pain area handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,6 +267,7 @@
         return !!equipment[need];
       });
     };
+    const normalizePainAreas = pain => Array.isArray(pain) ? pain : pain ? [pain] : [];
     const filterByGoal = (exs, goal) => {
       return exs.filter(ex => {
         const lvl = parseInt(levelOf(ex).split(':')[1],10) || 1;
@@ -288,7 +289,8 @@
         'таз/спина':['area:hips','area:core'], 'задняя цепь':['area:hamstrings'],
         'стопа/голеностоп':['area:ankle']
       };
-      const ban = new Set(); painAreas.forEach(p => (painMap[p]||[]).forEach(t=>ban.add(t)));
+      const list = normalizePainAreas(painAreas);
+      const ban = new Set(); list.forEach(p => (painMap[p]||[]).forEach(t=>ban.add(t)));
       return exs.filter(ex => !ex.tags.some(t => ban.has(t)));
     };
     const filterByLevelRPE = (exs, rpe, lowStreak) => {
@@ -569,7 +571,11 @@
     // ---------- RPE modal ----------
     const RPEModal = ({ open, onClose, value, onChange, painAreas, setPainAreas }) => {
       if (!open) return null;
-      const toggleArea = a => setPainAreas(prev => prev.includes(a) ? prev.filter(x=>x!==a) : [...prev,a]);
+      const normalizedPainAreas = normalizePainAreas(painAreas);
+      const toggleArea = a => setPainAreas(prev => {
+        const list = normalizePainAreas(prev);
+        return list.includes(a) ? list.filter(x=>x!==a) : [...list,a];
+      });
       return (
         <div className="modal" role="dialog" aria-modal="true" aria-label="Самочувствие">
           <div className="modal-card p-6">
@@ -588,7 +594,7 @@
                 <div className="text-sm font-medium text-gray-700 mb-2">Есть чувствительность/боль?</div>
                 <div className="flex flex-wrap gap-2">
                   {['шея','плечо','таз/спина','задняя цепь','стопа/голеностоп'].map(a=>(
-                    <button key={a} onClick={()=>toggleArea(a)} className={`px-3 py-1.5 rounded-lg border ${painAreas.includes(a)?'bg-red-50 border-red-300 text-red-700':'bg-white border-gray-200 text-gray-700'}`} aria-pressed={painAreas.includes(a)}>{a}</button>
+                    <button key={a} onClick={()=>toggleArea(a)} className={`px-3 py-1.5 rounded-lg border ${normalizedPainAreas.includes(a)?'bg-red-50 border-red-300 text-red-700':'bg-white border-gray-200 text-gray-700'}`} aria-pressed={normalizedPainAreas.includes(a)}>{a}</button>
                   ))}
                 </div>
                 <div className="text-xs text-gray-500 mt-2">Мы подстроим сложность и исключим конфликтующие упражнения.</div>
@@ -740,7 +746,7 @@
       const [day,setDay]=useState(1);
       const [rpe,setRpe]=useState(LS.get('user.rpe', 4));
       const [rpeHistory,setRpeHistory]=useState(LS.get('user.rpeHistory', [])); // last N
-      const [painAreas,setPainAreas]=useState(LS.get('user.pain', []));
+      const [painAreas,setPainAreas]=useState(()=>normalizePainAreas(LS.get('user.pain', [])));
       const [showRPE,setShowRPE]=useState(false);
       const [plan,setPlan]=useState(LS.get('plan.v2', {}));
       const [history,setHistory]=useState(LS.get('generator.history.v2', [])); // [{w,d,area,minutes}...]
@@ -938,7 +944,7 @@
       useEffect(()=>{
         if (!profile) return;
         const lastAreas = history.slice(0,3).map(h=>h.area);
-        const gen = generatePlan({ week, day, theme, rpe, pain: painAreas, lastAreas, rpeLowStreak: lowStreak, profile });
+        const gen = generatePlan({ week, day, theme, rpe, pain: normalizePainAreas(painAreas), lastAreas, rpeLowStreak: lowStreak, profile });
         setPlan(prev => ({ ...prev, [key]: gen }));
         // push history
         const minutes = Object.values(gen.targets).reduce((a,b)=>a+b,0);


### PR DESCRIPTION
## Summary
- add a helper to normalize pain area selections and reuse it in exercise filtering and the RPE modal
- ensure pain areas loaded from localStorage are converted to arrays before generating plans

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2438ac694832d94474f1e7c62b556