### PR TITLE
Add media metadata and enrich exercise replacement UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,18 +138,59 @@
     }
     const APP = ensureSeed();
 
+    const ensureArray = (value) => Array.isArray(value) ? value.filter(Boolean) : (value ? [value] : []);
+    const metaLabel = (item) => {
+      if (!item) return '';
+      if (typeof item === 'string') return item;
+      if (typeof item === 'object'){
+        return item.label || item.title || item.name || item.text || item.cue || item.description || item.note || item.detail || (item.id ? String(item.id) : '');
+      }
+      return String(item);
+    };
+    const metaNote = (item) => {
+      if (!item || typeof item !== 'object') return '';
+      return item.note || item.detail || item.description || item.subtitle || '';
+    };
+    const summarizeList = (items, max=2) => {
+      const arr = ensureArray(items);
+      if (!arr.length) return '';
+      const labels = arr.map(metaLabel).filter(Boolean);
+      if (!labels.length) return '';
+      const shown = labels.slice(0,max).join(', ');
+      return labels.length>max ? `${shown}…` : shown;
+    };
+    const withExerciseMeta = (list) => list.map(ex => ({
+      video_url: null,
+      modifications: [],
+      variations: [],
+      cueing: [],
+      red_flags: [],
+      alternatives: [],
+      ...ex
+    }));
+
     // ---------- RNG ----------
     function mulberry32(a){ return function(){ var t = a += 0x6D2B79F5; t = Math.imul(t ^ t >>> 15, t | 1); t ^= t + Math.imul(t ^ t >>> 7, t | 61); return ((t ^ t >>> 14) >>> 0) / 4294967296; } }
     function strSeed(s){ let h=2166136261; for (let i=0;i<s.length;i++){ h^=s.charCodeAt(i); h = Math.imul(h, 16777619); } return h>>>0; }
     const rngFrom = (seedStr)=> mulberry32(strSeed(seedStr));
 
     // ---------- Data (subset, enriched) ----------
-    const EX_STRETCH = [
+    const EX_STRETCH = withExerciseMeta([
       {id:'neck_decompress', name:'Декомпрессия шеи', duration:5, equipment:'none', tags:['area:neck','type:mobility','lvl:1','pos:sitting'],
         steps:['Сядь устойчиво, плечи вниз','Наклон головы вправо 20–30 сек','Вернись и повтори влево','Подбородок к груди 20 сек'],
         focus:['Тянемся макушкой','Выдох — отпускание'], mistakes:['Рывки','Поднятые плечи'],
         mechanism:'Снижение гипертонуса трапециевидной и лестничных', contraindications:'Головокружение — остановить',
-        progressions:['neck_iso_antagonist'] },
+        progressions:['neck_iso_antagonist'],
+        video_url:'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4',
+        modifications:[
+          {label:'С опорой на стену', note:'Если долго сидеть неудобно, выполняй стоя с опорой затылка.'},
+          {label:'Полотенце под подмышкой', note:'Помогает отпустить плечо вниз без избыточного натяжения.'}
+        ],
+        variations:['Добавь лёгкое вытяжение руки вниз за запястье','Удерживай позиции по 2 длинных дыхательных цикла'],
+        cueing:['Вдох через нос — удлини макушку вверх','На выдохе отпускай плечи и смягчай челюсть'],
+        red_flags:['Онемение или резкая боль — прекрати и вернись в нейтраль'],
+        alternatives:[{id:'neck_iso_antagonist', note:'Если хочется активировать мышцы вместо пассивного вытяжения.'}]
+      },
       {id:'neck_iso_antagonist', name:'Изометрия антагонистов шеи', duration:6, equipment:'none', tags:['area:neck','type:stability','lvl:2','pos:sitting'],
         steps:['Ладонь к виску','Надави головой на ладонь 5 сек без движения','Расслабь 5 сек ×5 в стороны и вперёд'],
         focus:['Сохраняй нейтральный подбородок'], mistakes:['Переразгибание шеи'],
@@ -304,12 +345,22 @@
         steps:['Разметь крест на полу','Прыгай по линиям вперёд-назад, в стороны 20 сек','Смена ног'],
         focus:['Мягкое приземление'], mistakes:['Громкий удар пяткой'],
         mechanism:'Реактивная устойчивость голеностопа', contraindications:'Острая нестабильность голеностопа' }
-    ];
+    ]);
 
-    const EX_LFK = [
+    const EX_LFK = withExerciseMeta([
       {id:'quad_iso', name:'Изометрия квадрицепса', duration:6, equipment:'mat', tags:['area:core','type:stability','lvl:1'],
         steps:['Выпрями ногу','Прижимай колено 8 сек → расслабь 3 сек ×12'],
-        mechanism:'Нейромышечный контроль без осевой нагрузки' },
+        mechanism:'Нейромышечный контроль без осевой нагрузки',
+        video_url:'https://placehold.co/640x360.png?text=Quad+Iso',
+        modifications:[
+          {label:'С валиком под коленом', note:'Если пол твердый или больно полностью разгибать колено.'},
+          {label:'С поддержкой руками', note:'Ладони рядом для обратной связи и мягкого давления.'}
+        ],
+        variations:['Добавь подъём пятки на 3 сек в верхней точке','Делай попеременные толчки двумя ногами для симметрии'],
+        cueing:['Выдох — активируй квадрицепс, ощущай подтягивание надколенника','Сохраняй стопу расслабленной и взгляд вперёд'],
+        red_flags:['Острая боль в колене или отёк — перейти на пассивное разгрузочное положение'],
+        alternatives:[{id:'bridge', note:'Если нужна интеграция ягодичных при сохранении низкой нагрузки.'}]
+      },
       {id:'deep_core', name:'Глубокие стабилизаторы (TA/multifidus)', duration:6, equipment:'mat', tags:['area:core','type:stability','lvl:2'],
         steps:['Лёжа, колени 90°','Втяни живот на ~30%, удерживай 10 сек','Отдых 5 сек ×15'],
         mechanism:'Активация поперечной и межостистых' },
@@ -514,12 +565,22 @@
       {id:'balance_clock_reach', name:'Часы с касаниями', duration:5, equipment:'none', tags:['area:balance','type:balance','lvl:2','pos:standing'],
         steps:['Опорная нога центр, другой ногой касайся направлений 12-2-4-6-8-10','Контроль корпуса, лёгкие касания','2 круга/сторона'],
         mechanism:'Многоплоскостная устойчивость' }
-    ];
+    ]);
 
-    const EX_MEDIT = [
+    const EX_MEDIT = withExerciseMeta([
       {id:'478', name:'Дыхание 4‑7‑8', duration:10, equipment:'none', tags:['area:breath','type:breath','lvl:1'],
         steps:['Выдох ртом','Вдох носом 4','Пауза 7','Выдох 8 ×4–8 циклов'],
-        mechanism:'Активация парасимпатики, снижение ЧСС' },
+        mechanism:'Активация парасимпатики, снижение ЧСС',
+        video_url:'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4',
+        modifications:[
+          {label:'С опорой спины', note:'Сядь у стены, если тяжело сохранять прямую осанку.'},
+          {label:'Лёжа', note:'Подходит перед сном или при головокружении в сидячем положении.'}
+        ],
+        variations:['Удлинённый цикл 5‑7‑8 для опытных практиков','Добавь счёт на пальцах для тактильной поддержки'],
+        cueing:['Вдох как наполнение боков рёбер','На выдохе ощущай мягкое «стравливание» напряжения в животе'],
+        red_flags:['При головокружении сократи задержку на паузе или вернись к обычному дыханию'],
+        alternatives:[{id:'coherent_breath', note:'Если нужна более плавная и ровная дыхательная практика.'}]
+      },
       {id:'pmr', name:'Прогрессивная релаксация', duration:15, equipment:'mat', tags:['area:breath','type:awareness','lvl:1'],
         steps:['Напряги мышцу 7 сек → расслабь 15 сек','Стопы→голени→бёдра→ягодицы→живот→спина→плечи→руки→шея→лицо'],
         mechanism:'Обучение напряжение/релаксация' },
@@ -589,7 +650,7 @@
       {id:'even_breath_noting', name:'Дыхание с отслеживанием «вдох-выдох»', duration:10, equipment:'none', tags:['area:breath','type:awareness','lvl:1'],
         steps:['Ментально проговаривай «вдох» и «выдох»','Если отвлёкся — мягко возвращайся','Держи темп 4/4'],
         mechanism:'Укрепление концентрации и осознанности' }
-    ];
+    ]);
 
     const EX_LOOKUP = {};
     [...EX_STRETCH, ...EX_LFK, ...EX_MEDIT].forEach(ex => { EX_LOOKUP[ex.id] = ex; });
@@ -744,18 +805,40 @@
     }
 
     // Replace ranking
-    function rankAlternatives(ex, cand){
+    function rankAlternatives(ex, cand, context={}){
       const lvlNum = l => parseInt((l||'lvl:1').split(':')[1],10)||1;
       const exLvl = lvlNum(levelOf(ex));
       const usage = countUsage(cand.map(c=>c.id));
+      const availableEquipment = context.equipment ? Object.entries(context.equipment).filter(([,v])=>v).map(([key])=>EQUIPMENT_LABELS[key]||key) : [];
+      const painList = ensureArray(context.painAreas);
+      const selectedMods = ensureArray(context.selectedMods);
       return cand.map(c => {
-        const score = (areaOf(c)===areaOf(ex)?3:0) + (typeOf(c)===typeOf(ex)?2:0) - Math.abs(lvlNum(levelOf(c))-exLvl) + (4/(1+(usage.get(c.id)||0)));
-        const reason = [
+        const modSummary = summarizeList(c.modifications, 2);
+        const sharedMods = selectedMods.length && modSummary ? summarizeList(selectedMods, 1) : '';
+        let score = (areaOf(c)===areaOf(ex)?3:0) + (typeOf(c)===typeOf(ex)?2:0) - Math.abs(lvlNum(levelOf(c))-exLvl) + (4/(1+(usage.get(c.id)||0)));
+        if (modSummary) score += 0.5;
+        if (painList.length && (!c.red_flags || c.red_flags.length===0)) score += 0.25;
+        const reasonParts = [
           areaOf(c)===areaOf(ex)?'та же область':null,
           typeOf(c)===typeOf(ex)?'тот же тип':null,
           `уровень ${levelOf(c).split(':')[1]}`
-        ].filter(Boolean).join(', ');
-        return { ...c, __score: score, __why: reason };
+        ];
+        if (sharedMods){
+          reasonParts.push(`поддерживает выбранные модификации (${sharedMods} → ${modSummary})`);
+        } else if (modSummary){
+          reasonParts.push(`есть модификации: ${modSummary}`);
+        }
+        if (availableEquipment.length){
+          const eqLabel = EQUIPMENT_LABELS[c.equipment||'none'] || EQUIPMENT_LABELS.none;
+          reasonParts.push(`совместимо с вашим оборудованием (${eqLabel.toLowerCase()})`);
+        }
+        if (painList.length){
+          reasonParts.push(`учитывает ограничения по зонам боли (${painList.join(', ')})`);
+        }
+        if (c.red_flags && c.red_flags.length){
+          reasonParts.push(`обрати внимание: ${metaLabel(c.red_flags[0])}`);
+        }
+        return { ...c, __score: score, __why: reasonParts.filter(Boolean).join(', ') };
       }).sort((a,b)=> b.__score - a.__score);
     }
 
@@ -800,6 +883,44 @@
     const ExerciseItem = ({ ex, onReplace, onStartTimer, done, onToggleDone, goal }) => {
       const [open,setOpen]=useState(false);
       const equipmentLabel = EQUIPMENT_LABELS[ex.equipment||'none'] || EQUIPMENT_LABELS.none;
+      const modifications = ensureArray(ex.modifications);
+      const variations = ensureArray(ex.variations);
+      const cueing = ensureArray(ex.cueing);
+      const redFlags = ensureArray(ex.red_flags);
+      const alternatives = ensureArray(ex.alternatives).map(item => {
+        if (!item) return null;
+        if (typeof item === 'string') return { id:item };
+        return item;
+      }).filter(Boolean);
+      const mediaUrl = typeof ex.video_url === 'string' ? ex.video_url.trim() : '';
+      const isVideo = /\.(mp4|webm|ogg)(\?|$)/i.test(mediaUrl);
+      const hasMeta = modifications.length || variations.length || cueing.length || redFlags.length || alternatives.length;
+      const renderMetaList = (title, items, options={}) => {
+        const { tone='default', italic=false, fullWidth=false } = options;
+        if (!items || !items.length) return null;
+        const containerTone = tone==='warning' ? 'bg-rose-50 border border-rose-200' : 'bg-gray-50 border border-gray-100';
+        const textTone = tone==='warning' ? 'text-rose-700' : 'text-gray-700';
+        const titleTone = tone==='warning' ? 'text-rose-700' : 'text-gray-600';
+        const spanClass = italic ? 'italic' : '';
+        const widthClass = (tone==='warning' || fullWidth) ? 'sm:col-span-2' : '';
+        return (
+          <div className={`rounded-xl p-3 ${containerTone} ${widthClass}`}>
+            <div className={`text-xs font-semibold uppercase tracking-wider mb-1 ${titleTone}`}>{title}</div>
+            <ul className="list-disc pl-4 space-y-1">
+              {items.map((item,i)=>{
+                const label = metaLabel(item);
+                const note = metaNote(item);
+                return (
+                  <li key={i} className={`text-sm leading-relaxed ${textTone}`}>
+                    <span className={spanClass}>{label}</span>
+                    {note && <div className="text-xs opacity-80 not-italic mt-0.5">{note}</div>}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        );
+      };
       return (
         <div className={"border-b border-gray-100 last:border-b-0 "+(open?'bg-white':'hover:bg-gray-50')}>
           <div className="flex items-center justify-between p-4">
@@ -826,6 +947,21 @@
           </div>
           <div className={"acc-enter "+(open?'open':'')}>
             <div className="px-4 pb-5">
+              {mediaUrl && (
+                <figure className="mb-4">
+                  <div className="relative w-full overflow-hidden rounded-xl bg-gray-100 aspect-video">
+                    {isVideo ? (
+                      <video className="w-full h-full object-cover" controls preload="metadata" playsInline aria-label={`Видео демонстрация: ${ex.name}`}>
+                        <source src={mediaUrl} />
+                        Ваш браузер не поддерживает воспроизведение видео.
+                      </video>
+                    ) : (
+                      <img src={mediaUrl} alt={`Превью упражнения: ${ex.name}`} className="w-full h-full object-cover" loading="lazy" />
+                    )}
+                  </div>
+                  <figcaption className="mt-1 text-xs text-gray-500">Демонстрация упражнения «{ex.name}».</figcaption>
+                </figure>
+              )}
               {ex.steps && ex.steps.length>0 && (
                 <div className="mb-3">
                   <div className="text-xs font-semibold text-gray-600 uppercase tracking-wider mb-2">Шаги</div>
@@ -842,6 +978,32 @@
                 <div className="mb-2">
                   <div className="text-xs font-semibold text-gray-600 uppercase mb-1">Прогрессии</div>
                   <ul className="list-disc pl-5 text-sm text-gray-700">{ex.progressions.map(pid => <li key={pid}>{EX_LOOKUP[pid]?.name || pid}</li>)}</ul>
+                </div>
+              )}
+              {hasMeta && (
+                <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                  {renderMetaList('Модификации', modifications)}
+                  {renderMetaList('Вариации', variations)}
+                  {renderMetaList('Подсказки по дыханию и ощущениям', cueing, { italic:true })}
+                  {renderMetaList('Красные флаги', redFlags, { tone:'warning' })}
+                  {alternatives.length>0 && (
+                    <div className="rounded-xl border border-gray-200 p-3 bg-white sm:col-span-2">
+                      <div className="text-xs font-semibold text-gray-600 uppercase tracking-wider mb-1">Альтернативы</div>
+                      <ul className="space-y-2">
+                        {alternatives.map((alt,i)=>{
+                          const target = alt.id ? EX_LOOKUP[alt.id] : null;
+                          const label = alt.name || target?.name || metaLabel(alt);
+                          const note = alt.note || metaNote(alt);
+                          return (
+                            <li key={alt.id || i} className="text-sm text-gray-800">
+                              <span className="font-medium">{label}</span>
+                              {note && <div className="text-xs text-gray-500 mt-0.5">{note}</div>}
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    </div>
+                  )}
                 </div>
               )}
               {ex.mechanism && <div className="bg-gray-50 border border-gray-100 rounded-xl p-3 text-sm text-gray-800"><b>Зачем:</b> {ex.mechanism}</div>}
@@ -870,7 +1032,16 @@
                 <button key={alt.id} onClick={()=>onPick(alt)} className="w-full text-left p-3 rounded-xl border border-gray-200 hover:bg-gray-50" aria-label={`Выбрать: ${alt.name}`}>
                   <div className="font-medium text-gray-900">{alt.name}</div>
                   <div className="text-xs text-gray-600 mt-0.5">~ {alt.duration} мин • {alt.tags.join(', ').replace(/(area:|type:|lvl:)/g,'')}</div>
-                  <div className="text-xs text-gray-500 mt-1">Почему подходит: {alt.__why}</div>
+                  {alt.modifications && alt.modifications.length>0 && (
+                    <div className="text-xs text-gray-600 mt-1">Модификации: {summarizeList(alt.modifications, 2)}</div>
+                  )}
+                  {alt.cueing && alt.cueing.length>0 && (
+                    <div className="text-xs text-gray-500 mt-1">Подсказки: {summarizeList(alt.cueing, 1)}</div>
+                  )}
+                  {alt.red_flags && alt.red_flags.length>0 && (
+                    <div className="text-xs text-rose-600 mt-1">⚠ {metaLabel(alt.red_flags[0])}</div>
+                  )}
+                  {alt.__why && <div className="text-xs text-gray-500 mt-1">Почему подходит: {alt.__why}</div>}
                 </button>
               ))}
             </div>
@@ -1336,32 +1507,34 @@
         const all = dataMap[listName]||[];
         const goal = profile?.goal || 'prevent';
         const eq = profile?.equipment ? { ...EQUIPMENT_DEFAULTS, ...profile.equipment } : { ...EQUIPMENT_DEFAULTS };
+        const painList = normalizePainAreas(painAreas);
+        const context = { equipment:eq, painAreas:painList, selectedMods: ex.modifications };
         // candidates: prefer same type & area; фильтры цели/оборудования/боли
         let cand = all.filter(c => c.id!==ex.id);
         cand = filterByGoal(cand, goal);
         cand = filterByEquipment(cand, eq);
-        cand = filterByPain(cand, painAreas);
+        cand = filterByPain(cand, painList);
         cand = filterByLevelRPE(cand, rpe, lowStreak);
         if (listName==='lfkList') cand = excludeStrengthIfHighRPE(cand, rpe, goal);
         // rank by match + rarity
-        cand = rankAlternatives(ex, cand);
+        cand = rankAlternatives(ex, cand, context);
         // guarantee at least 2: if empty, relax to same type only, then lvl:1 any
         if (cand.length<2){
           let extra = all.filter(c => c.id!==ex.id && typeOf(c)===typeOf(ex));
           extra = filterByGoal(extra, goal);
           extra = filterByEquipment(extra, eq);
-          extra = filterByPain(extra, painAreas);
+          extra = filterByPain(extra, painList);
           extra = filterByLevelRPE(extra, rpe, lowStreak);
-          extra = rankAlternatives(ex, extra);
+          extra = rankAlternatives(ex, extra, context);
           cand = [...cand, ...extra].filter((v,i,a)=>a.findIndex(x=>x.id===v.id)===i);
         }
         if (cand.length<2){
           let extra = all.filter(c => c.id!==ex.id && levelOf(c)==='lvl:1');
           extra = filterByGoal(extra, goal);
           extra = filterByEquipment(extra, eq);
-          extra = filterByPain(extra, painAreas);
+          extra = filterByPain(extra, painList);
           extra = filterByLevelRPE(extra, rpe, lowStreak);
-          extra = rankAlternatives(ex, extra);
+          extra = rankAlternatives(ex, extra, context);
           cand = [...cand, ...extra].filter((v,i,a)=>a.findIndex(x=>x.id===v.id)===i);
         }
         cand = cand.slice(0,6);


### PR DESCRIPTION
## Summary
- add shared helpers to extend exercise records with media, modifications, cues, and alternatives
- surface media previews and new guidance blocks inside exercise details and replacement modal
- adjust replacement ranking context to mention user constraints in the reasoning copy

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e275ccf5b8832da5f005046cf49848